### PR TITLE
Log timestamp with millisecond precision

### DIFF
--- a/lib/identity/logging/railtie.rb
+++ b/lib/identity/logging/railtie.rb
@@ -15,7 +15,7 @@ module Identity
       end
 
       config.lograge.custom_options = lambda do |event|
-        event.payload[:timestamp] = Time.zone.now.iso8601
+        event.payload[:timestamp] = Time.zone.now.iso8601(3)
         event.payload[:uuid] = SecureRandom.uuid
         event.payload[:pid] = Process.pid
         event.payload[:user_agent] = event.payload[:request].user_agent

--- a/lib/identity/logging/version.rb
+++ b/lib/identity/logging/version.rb
@@ -1,5 +1,5 @@
 module Identity
   module Logging
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/spec/identity/logging/railtie_spec.rb
+++ b/spec/identity/logging/railtie_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Identity::Logging::Railtie do
         controller: 'Users::SessionsController',
         action: 'new',
         path: '/',
-        timestamp: now.iso8601,
+        timestamp: now.iso8601(3),
         host: 'host.example.com',
         user_agent: 'Chrome 1234',
         trace_id: amzn_trace_id,


### PR DESCRIPTION
Does what is says on the tin. Example of what the change results in:

```ruby
time.iso8601
# => "2024-06-06T20:20:04Z"
time.iso8601(3)
# => "2024-06-06T20:20:04.623Z"
```